### PR TITLE
Remove unsafe pointer. Use interface{} instead.

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -57,7 +57,6 @@ Example:
 			return nil, nil
 		}
 		data := &customProviderData{User: user}
-
 		cbPayload.SetPayload(data)
 		return user.Secret, nil
 	}

--- a/vangoh.go
+++ b/vangoh.go
@@ -305,7 +305,6 @@ func (vg *Vangoh) AuthenticateRequest(r *http.Request) *AuthenticationError {
 	// Calculate the b64 signature and compare against the one sent by the client.
 	expectedSignature := vg.ConstructSignature(r, secret)
 	expectedSignatureB64 := base64.StdEncoding.EncodeToString(expectedSignature)
-
 	if subtle.ConstantTimeCompare([]byte(expectedSignatureB64), []byte(actualSignatureB64)) != 1 {
 		return ErrorHMACSignatureMismatch
 	}


### PR DESCRIPTION
Change Provider Interface to use "CallbackPayload" struct, which simply wraps a single interface{} variable.

*This is a breaking change* for users who have already implemented SecretProviderWithCallback.